### PR TITLE
:sparkles: Feat: 소비 내역 조회 및 관리 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
 	implementation 'commons-fileupload:commons-fileupload:1.5'
+	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/backend/controller/ConsumptionController.java
+++ b/src/main/java/com/project/backend/controller/ConsumptionController.java
@@ -1,0 +1,74 @@
+package com.project.backend.controller;
+
+
+import com.project.backend.dto.ConsumptionDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Consumption",description = "소비 내역 관리 API")
+@RestController
+@RequestMapping("/api/consumptions")
+@RequiredArgsConstructor
+public class ConsumptionController {
+
+    private final ConsumptionService consumptionService;
+
+    @Operation(summary = "소비 내역 생성", description = "새로운 소비 내역을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<Integer> createConsumption(
+            @RequestBody ConsumptionDto.ConsumptionRequestDto requestDto) {
+        Integer consumptionId = consumptionService.createConsumption(requestDto);
+        return ResponseEntity.ok(consumptionId);
+    }
+
+    @Operation(summary = "전체 소비 내역 조회", description = "모든 소비 내역을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<ConsumptionDto.ConsumptionResponseDto>> getAllConsumption() {
+        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionService.getAllConsumptions();
+        return ResponseEntity.ok(consumptions);
+    }
+
+    @Operation(summary = "소비 내역 조회", description = "특정 소비 내역을 조회합니다.")
+    @GetMapping("/{consumptionId}")
+    public ResponseEntity<ConsumptionDto.ConsumptionResponseDto> getConsumptionById(
+            @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId) {
+        ConsumptionDto.ConsumptionResponseDto consumption = consumptionService.getConsumption(consumptionId);
+        return ResponseEntity.ok(consumption);
+    }
+
+    @Operation(summary = "회원별 소비 내역 조회",description = "특정 회원의 소비 내역을 조회합니다.")
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<List<ConsumptionDto.ConsumptionResponseDto>> getConsumptionsByMemberId(
+            @Parameter(description = "회원 ID") @PathVariable Integer memberId) {
+        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionService.getConsumptionsByMemberId(memberId);
+        return ResponseEntity.ok(consumptions);
+    }
+
+    @Operation(summary = "소비 내역 수정", description = "소비 내역의 상세 정보를 수정합니다.")
+    @PatchMapping("/{consumptionId}")
+    public ResponseEntity<Void> updateConsumptionDetails(
+            @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId,
+            @RequestBody ConsumptionDto.ConsumptionRequestDto requestDto) {
+        consumptionService.updateConsumption(consumptionId, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "소비 내역 삭제", description = "소비 내역을 삭제합니다.")
+    @DeleteMapping("/{consumptionId}")
+    public ResponseEntity<Void> deleteConsumption(
+            @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId) {
+        consumptionService.deleteConsumption(consumptionId);
+        return ResponseEntity.ok().build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}

--- a/src/main/java/com/project/backend/controller/ConsumptionController.java
+++ b/src/main/java/com/project/backend/controller/ConsumptionController.java
@@ -2,6 +2,7 @@ package com.project.backend.controller;
 
 
 import com.project.backend.dto.ConsumptionDto;
+import com.project.backend.service.ConsumptionServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,20 +18,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ConsumptionController {
 
-    private final ConsumptionService consumptionService;
+    private final ConsumptionServiceImpl consumptionServiceImpl;
 
     @Operation(summary = "소비 내역 생성", description = "새로운 소비 내역을 생성합니다.")
     @PostMapping
     public ResponseEntity<Integer> createConsumption(
             @RequestBody ConsumptionDto.ConsumptionRequestDto requestDto) {
-        Integer consumptionId = consumptionService.createConsumption(requestDto);
+        Integer consumptionId = consumptionServiceImpl.createConsumption(requestDto);
         return ResponseEntity.ok(consumptionId);
     }
 
     @Operation(summary = "전체 소비 내역 조회", description = "모든 소비 내역을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<ConsumptionDto.ConsumptionResponseDto>> getAllConsumption() {
-        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionService.getAllConsumptions();
+        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionServiceImpl.getAllConsumption();
         return ResponseEntity.ok(consumptions);
     }
 
@@ -38,7 +39,7 @@ public class ConsumptionController {
     @GetMapping("/{consumptionId}")
     public ResponseEntity<ConsumptionDto.ConsumptionResponseDto> getConsumptionById(
             @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId) {
-        ConsumptionDto.ConsumptionResponseDto consumption = consumptionService.getConsumption(consumptionId);
+        ConsumptionDto.ConsumptionResponseDto consumption = consumptionServiceImpl.getConsumption(consumptionId);
         return ResponseEntity.ok(consumption);
     }
 
@@ -46,7 +47,7 @@ public class ConsumptionController {
     @GetMapping("/member/{memberId}")
     public ResponseEntity<List<ConsumptionDto.ConsumptionResponseDto>> getConsumptionsByMemberId(
             @Parameter(description = "회원 ID") @PathVariable Integer memberId) {
-        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionService.getConsumptionsByMemberId(memberId);
+        List<ConsumptionDto.ConsumptionResponseDto> consumptions = consumptionServiceImpl.getConsumptionsByMemberId(memberId);
         return ResponseEntity.ok(consumptions);
     }
 
@@ -55,7 +56,7 @@ public class ConsumptionController {
     public ResponseEntity<Void> updateConsumptionDetails(
             @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId,
             @RequestBody ConsumptionDto.ConsumptionRequestDto requestDto) {
-        consumptionService.updateConsumption(consumptionId, requestDto);
+        consumptionServiceImpl.updateConsumption(consumptionId, requestDto);
         return ResponseEntity.ok().build();
     }
 
@@ -63,7 +64,7 @@ public class ConsumptionController {
     @DeleteMapping("/{consumptionId}")
     public ResponseEntity<Void> deleteConsumption(
             @Parameter(description = "소비 내역 ID") @PathVariable Integer consumptionId) {
-        consumptionService.deleteConsumption(consumptionId);
+        consumptionServiceImpl.deleteConsumption(consumptionId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/project/backend/dto/ConsumptionDto.java
+++ b/src/main/java/com/project/backend/dto/ConsumptionDto.java
@@ -1,0 +1,72 @@
+package com.project.backend.dto;
+
+import com.project.backend.model.Consumption;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class ConsumptionDto {
+
+    //Request DTO
+    @Getter
+    @NoArgsConstructor
+    public static class ConsumptionRequestDto {
+        private Integer memberId;
+
+        @NotBlank(message = "소비 내역은 필수 입력값입니다.")
+        private String consumptionDetails;
+
+        @NotBlank(message = "카테고리는 필수 입력값입니다. ")
+        private String category;
+
+        private Integer spendingAmount;
+        private String date;
+
+        @Builder
+        public ConsumptionRequestDto(Integer memberId, String consumptionDetails, String category, Integer spendingAmount, String date) {
+            this.memberId = memberId;
+            this.consumptionDetails = consumptionDetails;
+            this.category = category;
+            this.spendingAmount = spendingAmount;
+            this.date = date;
+        }
+
+
+        public Consumption toEntity() {
+            return Consumption.builder()
+                    .memberId(memberId)
+                    .consumptionDetails(consumptionDetails)
+                    .category(category)
+                    .spendingAmount(spendingAmount)
+                    .date(date)
+                    .build();
+        }
+
+    }
+
+
+    // Response DTO
+    @Getter
+    public static class ConsumptionResponseDto {
+        private Integer consumptionId;
+        private Integer memberId;
+        private String consumptionDetails;
+        private String category;
+        private Integer spendingAmount;
+        private String date;
+
+    public ConsumptionResponseDto(Consumption consumption) {
+            this.consumptionId = consumption.getConsumptionId();
+            this.memberId = consumption.getMemberId();
+            this.consumptionDetails = consumption.getConsumptionDetails();
+            this.category = consumption.getCategory();
+            this.spendingAmount = consumption.getSpendingAmount();
+            this.date = consumption.getDate();
+    }
+
+    }
+}

--- a/src/main/java/com/project/backend/dto/ConsumptionDto.java
+++ b/src/main/java/com/project/backend/dto/ConsumptionDto.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 
@@ -34,7 +36,13 @@ public class ConsumptionDto {
             this.consumptionDetails = consumptionDetails;
             this.category = category;
             this.spendingAmount = spendingAmount;
-            this.date = date;
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            try {
+                this.date = dateFormat.parse(date);
+            } catch (ParseException e) {
+                e.printStackTrace(); // 로그를 출력하거나 적절한 예외 처리를 한다.
+                this.date = null; // 기본값 설정 또는 예외 처리에 따른 조치
+            }
         }
 
 

--- a/src/main/java/com/project/backend/dto/ConsumptionDto.java
+++ b/src/main/java/com/project/backend/dto/ConsumptionDto.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Date;
+
 
 public class ConsumptionDto {
 
@@ -24,7 +26,7 @@ public class ConsumptionDto {
         private String category;
 
         private Integer spendingAmount;
-        private String date;
+        private Date date;
 
         @Builder
         public ConsumptionRequestDto(Integer memberId, String consumptionDetails, String category, Integer spendingAmount, String date) {
@@ -57,7 +59,7 @@ public class ConsumptionDto {
         private String consumptionDetails;
         private String category;
         private Integer spendingAmount;
-        private String date;
+        private Date date;
 
     public ConsumptionResponseDto(Consumption consumption) {
             this.consumptionId = consumption.getConsumptionId();

--- a/src/main/java/com/project/backend/model/Consumption.java
+++ b/src/main/java/com/project/backend/model/Consumption.java
@@ -1,0 +1,31 @@
+package com.project.backend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+
+public class Consumption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer consumptionId;
+
+    private Integer memberId;
+    private String consumptionDetails;
+    private String category;
+    private  Integer spendingAmount;
+    private Date date;
+}

--- a/src/main/java/com/project/backend/model/Consumption.java
+++ b/src/main/java/com/project/backend/model/Consumption.java
@@ -1,5 +1,6 @@
 package com.project.backend.model;
 
+import com.project.backend.dto.ConsumptionDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Getter
@@ -28,4 +29,12 @@ public class Consumption {
     private String category;
     private  Integer spendingAmount;
     private Date date;
+
+    // 업데이트 메서드
+    public void updateDetails(ConsumptionDto.ConsumptionRequestDto requestDto){
+        this.consumptionDetails = requestDto.getConsumptionDetails();
+        this.category = requestDto.getCategory();
+        this.spendingAmount = requestDto.getSpendingAmount();
+        this.date = requestDto.getDate();
+    }
 }

--- a/src/main/java/com/project/backend/repository/ConsumptionRepository.java
+++ b/src/main/java/com/project/backend/repository/ConsumptionRepository.java
@@ -1,0 +1,17 @@
+package com.project.backend.repository;
+
+import com.project.backend.model.Consumption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ConsumptionRepository extends JpaRepository<Consumption, Integer> {
+
+    //특정 회원의 소비 내역 조회
+    List<Consumption> findByUserId(Integer memberId);
+
+    //특정 카테고리의 소비 내역 조회
+    List<Consumption> findByCategory(String category);
+}

--- a/src/main/java/com/project/backend/repository/ConsumptionRepository.java
+++ b/src/main/java/com/project/backend/repository/ConsumptionRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ConsumptionRepository extends JpaRepository<Consumption, Integer> {
 
     //특정 회원의 소비 내역 조회
-    List<Consumption> findByUserId(Integer memberId);
+    List<Consumption> findByMemberId(Integer memberId);
 
     //특정 카테고리의 소비 내역 조회
     List<Consumption> findByCategory(String category);

--- a/src/main/java/com/project/backend/service/ConsumptionService.java
+++ b/src/main/java/com/project/backend/service/ConsumptionService.java
@@ -1,0 +1,25 @@
+package com.project.backend.service;
+
+import com.project.backend.dto.ConsumptionDto;
+import java.util.List;
+
+public interface ConsumptionService {
+
+    //소비 내역 생성
+    Integer createConsumption(ConsumptionDto.ConsumptionRequestDto requestDto);
+
+    //전체 소비 내역 조회
+    List<ConsumptionDto.ConsumptionResponseDto> getAllConsumption();
+
+    //특정 소비 내역 조회
+    ConsumptionDto.ConsumptionResponseDto getConsumption(Integer consumptionId);
+
+    //특정 회원의 소비 내역 조회
+    List<ConsumptionDto.ConsumptionResponseDto> getConsumptionsByMemberId(Integer memberId);
+
+    //소비 내역 수정
+    void updateConsumption(Integer consumptionId, ConsumptionDto.ConsumptionRequestDto requestDto);
+
+    //소비 내역 삭제
+    void deleteConsumption(Integer consumptionId);
+}

--- a/src/main/java/com/project/backend/service/ConsumptionServiceImpl.java
+++ b/src/main/java/com/project/backend/service/ConsumptionServiceImpl.java
@@ -1,0 +1,47 @@
+package com.project.backend.service;
+
+import com.project.backend.dto.ConsumptionDto;
+import com.project.backend.model.Consumption;
+import com.project.backend.repository.ConsumptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionServiceImpl implements ConsumptionService {
+
+    private final ConsumptionRepository consumptionRepository;
+
+    @Override
+    public Integer createConsumption(ConsumptionDto.ConsumptionRequestDto requestDto) {
+        Consumption consumption = requestDto.toEntity();
+        consumption = consumptionRepository.save(consumption);
+        return consumption.getConsumptionId();
+    }
+
+    @Override
+    public List<ConsumptionDto.ConsumptionResponseDto> getAllConsumption() {
+        return consumptionRepository.findAll().stream()
+                .map(ConsumptionDto.ConsumptionResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void updateConsumption(Integer consumptionId, ConsumptionDto.ConsumptionRequestDto requestDto) {
+        Consumption consumption = consumptionRepository.findById(consumptionId)
+                .orElseThrow() -> new IllegalArgumentException("소비 내역을 찾을 수 없습니다.");
+        consumption.updateDetails(requestDto);
+        consumptionRepository.save(consumption);
+    }
+
+    @Override
+    public void deleteConsumption(Integer consumptionId) {
+        if (!consumptionRepository.existsById(consumptionId)) {
+            throw new IllegalArgumentException("소비 내역을 찾을 수 없습니다.");
+        }
+        consumptionRepository.deleteById(consumptionId);
+    }
+}

--- a/src/main/java/com/project/backend/service/ConsumptionServiceImpl.java
+++ b/src/main/java/com/project/backend/service/ConsumptionServiceImpl.java
@@ -32,7 +32,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
     @Override
     public void updateConsumption(Integer consumptionId, ConsumptionDto.ConsumptionRequestDto requestDto) {
         Consumption consumption = consumptionRepository.findById(consumptionId)
-                .orElseThrow() -> new IllegalArgumentException("소비 내역을 찾을 수 없습니다.");
+                .orElseThrow(() -> new IllegalArgumentException("소비 내역을 찾을 수 없습니다."));
         consumption.updateDetails(requestDto);
         consumptionRepository.save(consumption);
     }
@@ -43,5 +43,19 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             throw new IllegalArgumentException("소비 내역을 찾을 수 없습니다.");
         }
         consumptionRepository.deleteById(consumptionId);
+    }
+
+    @Override
+    public ConsumptionDto.ConsumptionResponseDto getConsumption(Integer consumptionId) {
+        Consumption consumption = consumptionRepository.findById(consumptionId)
+                .orElseThrow(() -> new IllegalArgumentException("소비 내역을 찾을 수 없습니다."));
+        return new ConsumptionDto.ConsumptionResponseDto(consumption);
+    }
+
+    @Override
+    public List<ConsumptionDto.ConsumptionResponseDto> getConsumptionsByMemberId(Integer memberId) {
+        return consumptionRepository.findByMemberId(memberId).stream()
+                .map(ConsumptionDto.ConsumptionResponseDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/project/backend/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/backend/service/MemberServiceImpl.java
@@ -1,4 +1,4 @@
-package com.project.backend.service.impl;
+package com.project.backend.service;
 
 import com.project.backend.dto.MemberDto;
 import com.project.backend.model.Member;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=KbBackend
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/kb_database?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=12341234
+spring.datasource.password=
 
 # JPA ??
 spring.jpa.show-sql=true


### PR DESCRIPTION
변경 사항 요약:
	•	새로운 소비 내역 기능 구현 완료

구현 내용:
	1.	조회 기능 추가:
	•	@GetMapping("/api/consumptions/{consumptionId}"): 특정 소비 내역을 ID로 조회하는 기능
	•	@GetMapping("/api/consumptions/member/{memberId}"): 특정 회원의 소비 내역을 조회하는 기능
	2.	관리 기능 추가:
	•	@PatchMapping("/api/consumptions/{consumptionId}"): 소비 내역 업데이트 기능
	•	@DeleteMapping("/api/consumptions/{consumptionId}"): 소비 내역 삭제 기능

주요 목적:
	•	프론트엔드 연동 준비를 위한 백엔드 소비 내역 API 기능 추가

검증 사항:
	•	Swagger를 통해 모든 API가 정상적으로 작동하는 것을 확인했습니다.
	•	프론트엔드에서 API 연동 테스트가 가능한 상태입니다.

